### PR TITLE
modify report when undefined property.

### DIFF
--- a/lib/power-assert-formatter.js
+++ b/lib/power-assert-formatter.js
@@ -120,7 +120,11 @@
 
     return {
         dump: function (obj) {
-            return JSON.stringify(obj);
+            var str = JSON.stringify(obj);
+            if (typeof str === 'undefined') {
+                return 'undefined';
+            }
+            return str;
         },
         format: function (context) {
             var renderer = new PowerAssertContextRenderer(this.dump, context);

--- a/test/power_assert_formatter_test.js
+++ b/test/power_assert_formatter_test.js
@@ -99,6 +99,19 @@ q.test('typeof operator: assert(typeof foo !== "undefined");', function () {
     ]);
 });
 
+q.test('undefined property: assert({}.hoge === "xxx");', function () {
+    assert.ok(eval(instrument('assert({}.hoge === "xxx");')));
+    q.deepEqual(powerAssertTextLines, [
+        '# /path/to/some_test.js:1',
+        '',
+        'assert({}.hoge === "xxx");',
+        '          |    |          ',
+        '          |    false      ',
+        '          undefined       ',
+        ''
+    ]);
+});
+
 
 q.test('assert((delete foo.bar) === false);', function () {
     var foo = {


### PR DESCRIPTION
I want to see more exact report when undefined property
but current report was "Cannot read property 'length' of undefined"  unreadable report for me.

つたない英語ですんまそん。
