### PR TITLE
make `_capt` and `_expr` methods not enumerable

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var capturable = require('./lib/capturable');
 var create = require('object-create');
 var slice = Array.prototype.slice;
 var extend = require('xtend/mutable');
+var define = require('define-properties');
 
 /**
  * Enhance Power Assert feature to assert function/object.
@@ -40,7 +41,7 @@ function empower (assert, formatter, options) {
     default:
         throw new Error('Cannot be here');
     }
-    extend(enhancedAssert, capturable());
+    define(enhancedAssert, capturable());
     return enhancedAssert;
 }
 

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -5,7 +5,6 @@ var extend = require('xtend/mutable');
 var forEach = require('array-foreach');
 var map = require('array-map');
 var filter = require('array-filter');
-var capturable = require('./capturable');
 var decorate = require('./decorate');
 
 
@@ -31,7 +30,6 @@ Decorator.prototype.enhancement = function () {
             container[methodName] = decorate(callSpec, that);
         }
     });
-    extend(container, capturable());
     return container;
 };
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "array-foreach": "^1.0.1",
     "array-map": "0.0.0",
     "array-some": "^1.0.0",
+    "define-properties": "^1.1.2",
     "escallmatch": "^1.4.1",
     "object-create": "^0.1.0",
     "xtend": "^4.0.0"

--- a/test/empower_option_test.js
+++ b/test/empower_option_test.js
@@ -82,8 +82,22 @@ function sharedTestsForEmpowerFunctionReturnValue () {
     test('has _capt method', function () {
         assert.equal(typeof this.empoweredAssert._capt, 'function');
     });
+    test('_capt method should not be enumerable', function () {
+        var key, enumerated = {};
+        for (key in this.empoweredAssert) {
+            enumerated[key] = this.empoweredAssert[key];
+        }
+        assert.equal(typeof enumerated['_capt'], 'undefined');
+    });
     test('has _expr method', function () {
         assert.equal(typeof this.empoweredAssert._expr, 'function');
+    });
+    test('_expr method should not be enumerable', function () {
+        var key, enumerated = {};
+        for (key in this.empoweredAssert) {
+            enumerated[key] = this.empoweredAssert[key];
+        }
+        assert.equal(typeof enumerated['_expr'], 'undefined');
     });
     test('has equal method', function () {
         assert.equal(typeof this.empoweredAssert.equal, 'function');


### PR DESCRIPTION
make `_capt` and `_expr` methods not enumerable

fixes #15 