### PR TITLE
Fix: dealing with `err.name` on Node v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
   - "6"
+  - "7"
+  - "8"
 before_install:
   - "npm install -g gulp"
   - "npm install -g bower"

--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ Then load (`empower` function is exported)
     <script type="text/javascript" src="./path/to/bower_components/empower/build/empower.js"></script>
 
 
+OUR SUPPORT POLICY
+---------------------------------------
+
+We support Node under maintenance. In other words, we stop supporting old Node version when [their maintenance ends](https://github.com/nodejs/LTS).
+
+We also support "modern enough" browsers such as Chrome, Firefox, Safari, Edge etc.
+
+Any other environments are not supported officially (means that we do not test against them on CI service). empower is known to work with old browsers, and trying to keep them working though.
+
+
 AUTHOR
 ---------------------------------------
 * [Takuto Wada](https://github.com/twada)

--- a/index.js
+++ b/index.js
@@ -42,18 +42,7 @@ function empower (assert, formatter, options) {
             }
             // console.log(JSON.stringify(errorEvent, null, 2));
             if (config.modifyMessageOnRethrow) {
-                var poweredMessage = buildPowerAssertText(formatter, errorEvent.originalMessage, errorEvent.powerAssertContext);
-                if (e.code === 'ERR_ASSERTION') {
-                    e = new assert.AssertionError({
-                        message: poweredMessage,
-                        actual: e.actual,
-                        expected: e.expected,
-                        operator: e.operator,
-                        stackStartFunction: e.stackStartFunction
-                    });
-                } else {
-                    e.message = poweredMessage;
-                }
+                e.message = buildPowerAssertText(formatter, errorEvent.originalMessage, errorEvent.powerAssertContext);
             }
             if (config.saveContextOnRethrow) {
                 e.powerAssertContext = errorEvent.powerAssertContext;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "dependencies": {
-    "empower-core": "^0.6.1",
+    "empower-core": "^0.6.2",
     "core-js": "^2.0.0"
   },
   "devDependencies": {

--- a/test/buster_assertions_test.js
+++ b/test/buster_assertions_test.js
@@ -66,7 +66,7 @@
                 'assert(falsy)',
                 '[{"value":0,"espath":"arguments/0"}]'
             ].join('\n'));
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 
@@ -83,7 +83,7 @@
                     'assert.isNull(falsy)',
                     '[{"value":0,"espath":"arguments/0"}]: Expected 0 to be null'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
     });
@@ -101,7 +101,7 @@
                     'assert.same(foo, bar)',
                     '[{"value":"foo","espath":"arguments/0"},{"value":"bar","espath":"arguments/1"}]: foo expected to be the same object as bar'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
 
@@ -116,7 +116,7 @@
                     'assert.same("foo", bar)',
                     '[{"value":"bar","espath":"arguments/1"}]: foo expected to be the same object as bar'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
 
@@ -131,7 +131,7 @@
                     'assert.same(foo, "bar")',
                     '[{"value":"foo","espath":"arguments/0"}]: foo expected to be the same object as bar'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
     });
@@ -149,7 +149,7 @@
                     'assert.near(actualVal, expectedVal, delta)',
                     '[{"value":10.6,"espath":"arguments/0"},{"value":10,"espath":"arguments/1"},{"value":0.5,"espath":"arguments/2"}]: Expected 10.6 to be equal to 10 +/- 0.5'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
 
@@ -164,7 +164,7 @@
                     'assert.near(actualVal, expectedVal, delta, messageStr)',
                     '[{"value":10.6,"espath":"arguments/0"},{"value":10,"espath":"arguments/1"},{"value":0.5,"espath":"arguments/2"}]: Expected 10.6 to be equal to 10 +/- 0.5'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
     });

--- a/test/empower_test.js
+++ b/test/empower_test.js
@@ -68,7 +68,7 @@ test('default options behavior', function () {
             'assert(falsy)',
             '[{"value":0,"espath":"arguments/0"}]'
         ].join('\n'));
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 
@@ -105,7 +105,7 @@ test('Bug reproduction. should not fail if argument is null Literal. ' + JSON.st
                 ]
             });
         }
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 
@@ -140,7 +140,7 @@ test('assertion with optional message argument. ' + JSON.stringify(option), func
                 ]
             });
         }
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 
@@ -175,7 +175,7 @@ test(JSON.stringify(option) + ' empowered function also acts like an assert func
                 ]
             });
         }
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 
@@ -211,7 +211,7 @@ suite(JSON.stringify(option) + ' assertion method with one argument', function (
                     ]
                 });
             }
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 });
@@ -250,7 +250,7 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
                     ]
                 });
             }
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 
@@ -282,7 +282,7 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
                     ]
                 });
             }
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 
@@ -314,7 +314,7 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
                     ]
                 });
             }
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 });
@@ -355,7 +355,7 @@ suite(JSON.stringify(option) + ' yield for assertion inside generator', function
                         ]
                     });
                 }
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             } catch (e) {
                 return done (e);
             }
@@ -418,7 +418,7 @@ suite(JSON.stringify(option) + ' await assertion inside async async function', f
                         ]
                     });
                 }
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             } catch (e) {
                 return done (e);
             }
@@ -486,7 +486,7 @@ test('the case when assertion function call is not listed in patterns (even if m
         baseAssert.ok(false, 'AssertionError should be thrown');
     } catch (e) {
         baseAssert.equal(e.message, '0 == true', 'should not be empowered');
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 

--- a/test/not_espowered_case_test.js
+++ b/test/not_espowered_case_test.js
@@ -27,7 +27,7 @@ test(JSON.stringify(option) + ' argument is null Literal.', function () {
         eval('assert.equal(foo, null);');
         assert.ok(false, 'AssertionError should be thrown');
     } catch (e) {
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
         baseAssert((e.message === '\'foo\' == null' || e.message === '\"foo\" == null'));
         baseAssert(e.powerAssertContext === undefined);
     }
@@ -40,7 +40,7 @@ test(JSON.stringify(option) + ' empowered function also acts like an assert func
         eval('assert(falsy);');
         assert.ok(false, 'AssertionError should be thrown');
     } catch (e) {
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
         baseAssert.equal(e.message, '0 == true');
         baseAssert(e.powerAssertContext === undefined);
     }
@@ -54,7 +54,7 @@ suite(JSON.stringify(option) + ' assertion method with one argument', function (
             eval('assert.ok(falsy);');
             assert.ok(false, 'AssertionError should be thrown');
         } catch (e) {
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
             baseAssert.equal(e.message, '0 == true');
             baseAssert(e.powerAssertContext === undefined);
         }
@@ -69,7 +69,7 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
             eval('assert.equal(foo, bar);');
             assert.ok(false, 'AssertionError should be thrown');
         } catch (e) {
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
             baseAssert((e.message === '\'foo\' == \'bar\'' || e.message === '\"foo\" == \"bar\"'));
             baseAssert(e.powerAssertContext === undefined);
         }
@@ -81,7 +81,7 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
             eval('assert.equal("foo", bar);');
             assert.ok(false, 'AssertionError should be thrown');
         } catch (e) {
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
             baseAssert((e.message === '\'foo\' == \'bar\'' || e.message === '\"foo\" == \"bar\"'));
             baseAssert(e.powerAssertContext === undefined);
         }
@@ -93,7 +93,7 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
             eval('assert.equal(foo, "bar");');
             assert.ok(false, 'AssertionError should be thrown');
         } catch (e) {
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
             baseAssert((e.message === '\'foo\' == \'bar\'' || e.message === '\"foo\" == \"bar\"'));
             baseAssert(e.powerAssertContext === undefined);
         }


### PR DESCRIPTION
When `modifyMessageOnRethrow` option is truthy.

since Node v8 (and v7) does not update message on rethrow.

refs power-assert-js/power-assert#85