### PR TITLE
Re-instantiate AssertionError under Node v8 (and v7)

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,12 +31,12 @@ function empower (assert, formatter, options) {
             return false;
         }
         var ae = new assert.AssertionError({
-            actual: 'actual',
-            expected: 'expected',
+            actual: 123,
+            expected: 456,
             operator: '==='
         });
         ae.message = '[REPLACED MESSAGE]';
-        return /\'actual\' === \'expected\'/.test(ae.stack);
+        return !(/REPLACED MESSAGE/.test(ae.stack)) && /123 === 456/.test(ae.stack);
     })();
 
     var empowerCoreConfig = assign(config, {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var define = require('./lib/define-properties');
 function empower (assert, formatter, options) {
     var config = assign(defaultOptions(), options);
     var eagerEvaluation = !(config.modifyMessageOnRethrow || config.saveContextOnRethrow);
-    var shouldRecreateAssertionError = (function () {
+    var shouldRecreateAssertionError = (function isStackUnchanged () {
         if (typeof assert !== 'function') {
             return false;
         }
@@ -55,9 +55,9 @@ function empower (assert, formatter, options) {
             if (!errorEvent.powerAssertContext) {
                 throw e;
             }
-            // console.log(JSON.stringify(errorEvent, null, 2));
-            if (config.modifyMessageOnRethrow) {
-                var poweredMessage = buildPowerAssertText(formatter, errorEvent.originalMessage, errorEvent.powerAssertContext);
+            var poweredMessage;
+            if (config.modifyMessageOnRethrow || config.saveContextOnRethrow) {
+                poweredMessage = buildPowerAssertText(formatter, errorEvent.originalMessage, errorEvent.powerAssertContext);
                 if (shouldRecreateAssertionError) {
                     e = new assert.AssertionError({
                         message: poweredMessage,
@@ -66,9 +66,10 @@ function empower (assert, formatter, options) {
                         operator: e.operator,
                         stackStartFunction: e.stackStartFunction
                     });
-                } else {
-                    e.message = poweredMessage;
                 }
+            }
+            if (config.modifyMessageOnRethrow && !shouldRecreateAssertionError) {
+                e.message = poweredMessage;
             }
             if (config.saveContextOnRethrow) {
                 e.powerAssertContext = errorEvent.powerAssertContext;

--- a/test/empower_test.js
+++ b/test/empower_test.js
@@ -219,7 +219,7 @@ suite(JSON.stringify(option) + ' assertion method with one argument', function (
 
 suite(JSON.stringify(option) + ' assertion method with two arguments', function () {
     test('both Identifier', function () {
-        var foo = 'foo', bar = 'bar';
+        var foo = 123, bar = 456;
         try {
             eval(weave('assert.equal(foo, bar);'));
             baseAssert.ok(false, 'AssertionError should be thrown');
@@ -228,7 +228,7 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
                 baseAssert.equal(e.message, [
                     'test/some_test.js',
                     'assert.equal(foo, bar)',
-                    '[{"value":"foo","espath":"arguments/0"},{"value":"bar","espath":"arguments/1"}]'
+                    '[{"value":123,"espath":"arguments/0"},{"value":456,"espath":"arguments/1"}]'
                 ].join('\n'));
             }
             if (option.saveContextOnRethrow) {
@@ -240,17 +240,18 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
                     },
                     "args":[
                         {
-                            "value":"foo",
-                            "events":[{"value":"foo","espath":"arguments/0"}]
+                            "value": 123,
+                            "events":[{"value":123,"espath":"arguments/0"}]
                         },
                         {
-                            "value":"bar",
-                            "events":[{"value":"bar","espath":"arguments/1"}]
+                            "value": 456,
+                            "events":[{"value":456,"espath":"arguments/1"}]
                         }
                     ]
                 });
             }
             baseAssert(/^AssertionError/.test(e.name));
+            baseAssert(!/123 == 456/.test(e.stack));
         }
     });
 

--- a/test/empower_test.js
+++ b/test/empower_test.js
@@ -230,6 +230,7 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
                     'assert.equal(foo, bar)',
                     '[{"value":123,"espath":"arguments/0"},{"value":456,"espath":"arguments/1"}]'
                 ].join('\n'));
+                baseAssert(!/123 == 456/.test(e.stack));
             }
             if (option.saveContextOnRethrow) {
                 baseAssert.deepEqual(e.powerAssertContext, {
@@ -251,7 +252,6 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
                 });
             }
             baseAssert(/^AssertionError/.test(e.name));
-            baseAssert(!/123 == 456/.test(e.stack));
         }
     });
 


### PR DESCRIPTION
since their `err.stack` is unchanged even if `err.message` is updated.

- Mocha uses `err.message` for reporting
- But vanilla Node uses `err.stack` for reporting

Affects not only Node8 but Node7, so we cannot use `err.code` for feature detection.
So I wrote dirty feature detection code.
We should re-instantiate and throw AssertionError under Node8 (and Node7).

refs: https://github.com/power-assert-js/power-assert/issues/85