### PR TITLE
fix: treat power-assert message as "not generated" to avoid message override

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,12 @@ function empower (assert, formatter, options) {
                         operator: e.operator,
                         stackStartFunction: e.stackStartFunction || onError
                     });
+                    e.generatedMessage = false;
                 }
             }
             if (config.modifyMessageOnRethrow && !shouldRecreateAssertionError) {
                 e.message = poweredMessage;
+                e.generatedMessage = false;
             }
             if (config.saveContextOnRethrow) {
                 e.powerAssertContext = errorEvent.powerAssertContext;

--- a/test/empower_test.js
+++ b/test/empower_test.js
@@ -193,6 +193,7 @@ suite(JSON.stringify(option) + ' assertion method with one argument', function (
                 baseAssert(/test\/some_test\.js/.test(e.message));
                 baseAssert(/assert\.ok\(falsy\)/.test(e.message));
                 baseAssert(/\[{"value":0,"espath":"arguments\/0"}\]/.test(e.message));
+                baseAssert.equal(e.generatedMessage, false, 'set generatedMessage to false if modifyMessageOnRethrow');
             }
             if (option.saveContextOnRethrow) {
                 baseAssert.deepEqual(e.powerAssertContext, {


### PR DESCRIPTION
by setting `AssertionError.generatedMessage` to `false` so works well with Jest

https://github.com/facebook/jest/blob/ed95b36bb139aa5d0fea35780ab5043eccf3cdee/packages/jest-jasmine2/src/assert_support.js#L97